### PR TITLE
args를 이용하여 wandb project 이름 설정

### DIFF
--- a/train.py
+++ b/train.py
@@ -168,8 +168,8 @@ def main():
                         help='model type (default: klue/roberta-large)')
     parser.add_argument('--loss', type=str, default= 'LB',
                         help='LB: LabelSmoothing, CE: CrossEntropy')
-    parser.add_argument('--wandb_name', type=str, default= 'test',
-                        help='wandb name (default: test)')
+    parser.add_argument('--wandb_name', type=str, default= 'test-project',
+                        help='wandb name (default: test-project)')
 
 
     """hyperparameter"""
@@ -197,7 +197,7 @@ def main():
                         help='metric_for_best_model (default: micro f1 score')
     
     args= parser.parse_args()
-    wandb.init(project="test-project", entity="boostcamp_nlp_04", config = vars(args),)
+    wandb.init(project=args.wandb_name, entity="boostcamp_nlp_04", config = vars(args),)
     train(args)
 
 


### PR DESCRIPTION
### Fix : args.wandb_name 으로 wandb 프로젝트 이름 설정

@addadda15 @hyoeun98 @inbeomi @addadda15  @junseok0408 

리뷰해주세요!