### PR TITLE
Hotfix : delete metric_for_best_model argument - causing parse error

### DIFF
--- a/train.sh
+++ b/train.sh
@@ -10,7 +10,7 @@ python train.py \
 --model klue/roberta-large \
 --loss LB \
 --wandb_name test-project \
---epochs 20 \
+--epochs 1 \
 --lr 5e-5 \
 --batch 16 \
 --gradient_accum 2 \
@@ -19,5 +19,4 @@ python train.py \
 --eval_steps 500 \
 --save_steps 500 \
 --logging_steps 100 \
---weight_decay 0.01 \
---metric_for_best_model micro f1 score
+--weight_decay 0.01 


### PR DESCRIPTION
train.sh 에서 metric_for_best_model argument 를 파싱하는 과정 중 오류를 내서 급히 고칩니다. 잘 실행되는 것 확인했고 hotfix 라 리뷰는 건너뜁니다.